### PR TITLE
fix: android network crash

### DIFF
--- a/android/src/androidTest/kotlin/xyz/juicebox/sdk/ClientTest.kt
+++ b/android/src/androidTest/kotlin/xyz/juicebox/sdk/ClientTest.kt
@@ -127,6 +127,16 @@ class ClientTest {
         assertEquals(DeleteError.ASSERTION, exception.error)
     }
 
+    @Test
+    fun testConnectionFailure() {
+        val client = client("https://invalid-host.local")
+        assertThrows(RegisterException::class.java) {
+            runBlocking {
+                client.register("test".toByteArray(), "secret".toByteArray(), "info".toByteArray(), 5)
+            }
+        }
+    }
+
     private fun client(url: String): Client {
         val realmId1 = RealmId(string = "000102030405060708090A0B0C0D0E0F")
         val realmId2 = RealmId(string = "010102030405060708090A0B0C0D0E0F")


### PR DESCRIPTION
This pull request improves error handling in the HTTP client implementation and adds a new test to verify connection failures. The most significant changes are the addition of robust error handling for network operations and the introduction of a unit test to ensure proper exception handling when a connection cannot be established.

**Error handling improvements:**

* Added a `try-catch` block around the HTTP request logic in the `Client` class to catch all exceptions. If an error occurs, a default `Native.HttpResponse` with status code `0` and empty headers/body is returned, ensuring that failures are handled gracefully and do not crash the thread. [[1]](diffhunk://#diff-8049a239919007528e696b691a029d2784d7f85fbe1dc19d4a93d7a7ebf94825R126) [[2]](diffhunk://#diff-8049a239919007528e696b691a029d2784d7f85fbe1dc19d4a93d7a7ebf94825R184-R192)

**Testing enhancements:**

* Added a new test `testConnectionFailure` in `ClientTest.kt` to verify that a `RegisterException` is thrown when attempting to register with an invalid host, ensuring that connection failures are properly detected and reported.

**Code formatting and readability:**

* Improved formatting for trust manager initialization and header mapping to enhance readability and maintainability in the `Client` class. [[1]](diffhunk://#diff-8049a239919007528e696b691a029d2784d7f85fbe1dc19d4a93d7a7ebf94825L135-R137) [[2]](diffhunk://#diff-8049a239919007528e696b691a029d2784d7f85fbe1dc19d4a93d7a7ebf94825L170-R173)
[Copilot is generating a summary...]