### PR TITLE
chore: pin external GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/software-realm/action.yaml
+++ b/.github/actions/software-realm/action.yaml
@@ -46,7 +46,7 @@ runs:
 
     - name: Run Software Realm
       id: run-software-realm
-      uses: pyTooling/Actions/with-post-step@v0.4.5
+      uses: pyTooling/Actions/with-post-step@cc576ce25a588e4fd623f3a4ea528f397141e931 # v0.4.5
       if: ${{ inputs.start-realm-count > 0 }}
       with:
         main: |

--- a/.github/actions/software-realm/action.yaml
+++ b/.github/actions/software-realm/action.yaml
@@ -18,14 +18,14 @@ runs:
   using: "composite"
   steps:
     - name: Clone Software Realm
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         repository: 'juicebox-systems/juicebox-software-realm'
         path: 'juicebox-software-realm'
         ref: ${{ inputs.ref }}
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
       with:
         go-version: '1.21'
         check-latest: true
@@ -38,7 +38,7 @@ runs:
         mv jb-sw-realm /usr/local/bin
 
     - name: Build Tokens
-      uses: actions-rs/cargo@v1
+      uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
       if: ${{ inputs.start-realm-count > 0 }}
       with:
         args: -p juicebox_tokens_cli

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -22,19 +22,19 @@ jobs:
     runs-on: macOS-latest
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         submodules: recursive
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
       with:
         java-version: 11
         distribution: 'adopt'
         cache: 'gradle'
 
     - name: Build and Test
-      uses: ReactiveCircus/android-emulator-runner@v2
+      uses: ReactiveCircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2
       with:
         api-level: 33
         target: google_apis

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
-      - uses: rustsec/audit-check@v1.4.1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: rustsec/audit-check@dd51754d4e59da7395a4cd9b593f0ff2d61a9b95 # v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ignore: 'RUSTSEC-2023-0071'

--- a/.github/workflows/demos.yaml
+++ b/.github/workflows/demos.yaml
@@ -16,20 +16,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           default: true
           profile: minimal
           toolchain: ${{ env.INSTALL_RUST_VERSION }}
 
       - name: Use Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build Rust Demo
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         with:
           args: -p juicebox_demo_cli
           command: build
@@ -48,23 +48,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           default: true
           profile: minimal
           toolchain: ${{ env.INSTALL_RUST_VERSION }}
 
       - name: Use Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build FFI
         run: swift/ffi.sh
 
       - name: Use Swift Cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: swift/demo/.build
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
@@ -88,25 +88,25 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           default: true
           profile: minimal
           toolchain: ${{ env.INSTALL_RUST_VERSION }}
 
       - name: Use Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           # it's not possible to pin certs yet with the experimental fetch in node 18,
           # and our polyfill doesn't work well in 18. stick with 16 for now.
           node-version: 16
 
-      - uses: jetli/wasm-pack-action@v0.4.0
+      - uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
 
       - name: Build WASM
         run: wasm-pack build rust/sdk/bridge/wasm --out-dir ../../../../javascript/juicebox-sdk --out-name juicebox-sdk --target nodejs

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,13 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     # - name: Show cargo package versions before cache unpack
     #   run: cargo install --list && cbindgen -V && which cbindgen
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
       with:
         default: true
         profile: minimal
@@ -42,7 +42,7 @@ jobs:
     #   run: cargo install --list && cbindgen -V && which cbindgen
 
     - name: Use Rust Cache
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
     # - name: Show cached cargo package versions
     #   run: cargo install --list && cbindgen -V && which cbindgen
@@ -66,7 +66,7 @@ jobs:
     runs-on: macOS-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Swiftlint
         run: |
@@ -82,7 +82,7 @@ jobs:
           rustup default ${{ env.INSTALL_RUST_VERSION }}
 
       - name: Use Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build juicebox_sdk_ffi
         run: |
@@ -98,10 +98,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           components: rustfmt, clippy, rust-src
           default: true
@@ -109,15 +109,15 @@ jobs:
           toolchain: ${{ env.INSTALL_RUST_VERSION }}
 
       - name: Use Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run cargo build
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         with:
           command: build
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         with:
           args: --workspace
           command: test
@@ -125,13 +125,13 @@ jobs:
           RUST_BACKTRACE: '1'
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         with:
           args: --all -- --check
           command: fmt
 
       - name: Run clippy
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         with:
           args: --workspace --tests -- -D warnings
           command: clippy
@@ -140,13 +140,13 @@ jobs:
         uses: ./.github/actions/software-realm
 
       - name: Run software realm integration tests
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         with:
           args: -p juicebox_sdk software_realm --features software_realm_tests
           command: test
 
       - name: Build no_std
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
         env:
           # Enable nightly features on stable cargo/rustc for build-std.
           RUSTC_BOOTSTRAP: 1
@@ -160,7 +160,7 @@ jobs:
     timeout-minutes: 20
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Rust
         run: |
@@ -168,13 +168,13 @@ jobs:
           rustup default ${{ env.INSTALL_RUST_VERSION }}
 
       - name: Use Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build juicebox_sdk_jni
         run: ./android/jni.sh
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           java-version: 11
           distribution: 'adopt'
@@ -189,19 +189,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           default: true
           profile: minimal
           toolchain: ${{ env.INSTALL_RUST_VERSION }}
 
       - name: Use Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - uses: jetli/wasm-pack-action@v0.4.0
+      - uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
 
       - name: Run Tests
         run: WASM_BINDGEN_TEST_TIMEOUT=60 wasm-pack test --firefox --headless rust/sdk/bridge/wasm

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
 
@@ -37,12 +37,12 @@ jobs:
     needs: check-artifacts
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           java-version: 11
           distribution: adopt
@@ -63,19 +63,19 @@ jobs:
     needs: check-artifacts
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           default: true
           profile: minimal
           toolchain: ${{ env.INSTALL_RUST_VERSION }}
 
       - name: Use Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - uses: jetli/wasm-pack-action@v0.4.0
+      - uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
 
       - name: Build JavaScript Package
         run: >-
@@ -84,7 +84,7 @@ jobs:
           --out-name juicebox-sdk
           --target bundler
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
@@ -104,7 +104,7 @@ jobs:
     needs: check-artifacts
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
 


### PR DESCRIPTION
## Summary

- Pin all unpinned external GitHub Action `uses:` references to full 40-character commit SHAs
- Original version tags/branches preserved as inline comments for maintainability
- No other CI changes included

## Motivation

Supply chain security hardening: pinning actions to immutable commit SHAs prevents silent changes from compromised or force-pushed tags.

Part of the org-wide audit tracked in [SEC-6683](https://linear.app/phantom-labs/issue/SEC-6683) and [SEC-7928](https://linear.app/phantom-labs/issue/SEC-7928).

## Test plan

- [ ] CI passes on this branch
- [ ] Verify pinned SHAs match the expected versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions references across all CI/CD workflow files, pinning build-related action dependencies to specific commit hashes instead of version tags for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->